### PR TITLE
bin/proj wont run, fix bugs

### DIFF
--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -71,7 +71,6 @@
 
 (def defaults
   {:name           (git/project-name)
-   :version        (git/version-string)
    :sha            (git/current-sha)
    :group-id       nil
    :gh-project     (str "lambdaisland/" (git/project-name))

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -67,7 +67,7 @@
 
    "bump-version"
    {:description "Bump minor version"
-    :command release/bump-version}])
+    :command version/bump-version!}])
 
 (def defaults
   {:name           (git/project-name)

--- a/src/lioss/version.clj
+++ b/src/lioss/version.clj
@@ -56,7 +56,7 @@
   "Add version info to the opts map, needs to be called again if the version
   changes."
   [opts]
-  (let [opt      (assoc opts :version (read-version-string))
+  (let [opts      (assoc opts :version (read-version-string))
         mod-vers (module-versions opts)]
     (-> opts
         (assoc :module-versions mod-vers)


### PR DESCRIPTION
`bin/proj` does not work on latest main resulting in the following errors

`bump-version` was moved to `version.clj`
```
➜  kaocha git:(main) ✗ bin/proj
Checking out: https://github.com/lambdaisland/open-source at e947aa589cdc136bffb84e374656bd3cb7b0ad23
----- Error --------------------------------------------------------------------
Type:     clojure.lang.ExceptionInfo
Message:  Could not resolve symbol: release/bump-version
Location: /Users/ox/.gitlibs/libs/lambdaisland/open-source/e947aa589cdc136bffb84e374656bd3cb7b0ad23/src/lioss/main.clj:70:14
Phase:    analysis

----- Context ------------------------------------------------------------------
66:     :command readme/do-update}
67:
68:    "bump-version"
69:    {:description "Bump minor version"
70:     :command release/bump-version}])
                 ^--- Could not resolve symbol: release/bump-version
71:
72: (def defaults
73:   {:name           (git/project-name)
74:    :version        (git/version-string)
75:    :sha            (git/current-sha)
```

`:version` is now being added separately in  a future call, no need for a default here
```
➜  kaocha git:(main) ✗ bin/proj install
----- Error --------------------------------------------------------------------
Type:     clojure.lang.ExceptionInfo
Message:  Could not resolve symbol: git/version-string
Location: /Users/ox/projects/open-source/src/lioss/main.clj:74:21
Phase:    analysis

----- Context ------------------------------------------------------------------
70:     :command version/bump-version!}])
71:
72: (def defaults
73:   {:name           (git/project-name)
74:    :version        (git/version-string)
                        ^--- Could not resolve symbol: git/version-string
75:    :sha            (git/current-sha)
76:    :group-id       nil
77:    :gh-project     (str "lambdaisland/" (git/project-name))
78:    :org-name       "Lambda Island"
79:    :org-url        "https://lambdaisland.com"
```

Again moved to `version.clj`
```
➜  kaocha git:(main) ✗ bin/proj install
----- Error --------------------------------------------------------------------
Type:     clojure.lang.ExceptionInfo
Message:  Could not resolve symbol: release/update-versions-in
Location: /Users/ox/projects/kaocha/bin/proj:11:6
Phase:    analysis

----- Context ------------------------------------------------------------------
 7:                    [lioss.release :as release]))
 8:
 9: (defn update-docs [opts]
10:   (doseq [file (filter #(str/ends-with? % ".md") (file-seq (io/file "doc")))]
11:     (release/update-versions-in file (:module-versions opts)))
         ^--- Could not resolve symbol: release/update-versions-in
12:   (subshell/spawn "sh" "-c" "ed < bin/update_toc.ed")
13:   opts)
14:
15: ;; TODO: run the cucumber to markdown code from here
16:
```

Now the most subtle bug of all

```
----- Error --------------------------------------------------------------------
Type:     java.lang.AssertionError
Message:  Assert failed: (:version opts)
Location: 37:3
```
This was all I got in the error.

After looking really hard found it 🙈 
```diff
(   "Add version info to the opts map, needs to be called again if the version
   changes."
   [opts]
-  (let [opt      (assoc opts :version (read-version-string))
+  (let [opts      (assoc opts :version (read-version-string))
         mod-vers (module-versions opts)]
     (-> opts
         (assoc :module-versions mod-vers)
```
I think I really should set up clj-condo