### PR TITLE
Support :old-group-id

### DIFF
--- a/src/lioss/pom.clj
+++ b/src/lioss/pom.clj
@@ -164,6 +164,29 @@
        [:name "Clojars repository"]
        [:url "https://clojars.org/repo"]]]]))
 
+(defn old-group-id-pom [opts]
+  (let [proj-name (:name opts)
+        version (:version opts)
+        old-group-id (:old-group-id opts)
+        group-id (:group-id opts)]
+    [:project {:xmlns "http://maven.apache.org/POM/4.0.0"
+               :xmlns:xsi "http://www.w3.org/2001/XMLSchema-instance"
+               :xsi:schemalocation "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"}
+     [:modelVersion "4.0.0"]
+     [:groupId old-group-id]
+     [:artifactId proj-name]
+     [:version version]
+     [:dependencies
+      [:dependency
+       [:groupId group-id]
+       [:artifactId proj-name]
+       [:version version]]]
+     [:distributionManagement
+      [:repository
+       [:id "clojars"]
+       [:name "Clojars repository"]
+       [:url "https://clojars.org/repo"]]]]))
+
 (defn spit-pom [h]
   (util/spit-cwd "pom.xml" (hiccup->xml h)))
 
@@ -174,3 +197,6 @@
 (defn spit-relocation-poms [opts]
   (spit-pom (relocation-pom opts))
   (util/do-modules opts (comp spit-pom relocation-pom)))
+
+(defn spit-old-group-id-pom [opts]
+  (spit-pom (old-group-id-pom opts)))

--- a/src/lioss/release.clj
+++ b/src/lioss/release.clj
@@ -96,6 +96,15 @@
       (pom/spit-poms opts)
       (util/do-modules opts (fn [_] (mvn "deploy")))
       (mvn "deploy")
+
+      ;; if :old-group-id is defined, create a new pom (in temp dir)
+      ;; with :old-group-id (name, version same) and points to the
+      ;; package under actual :group-id as a single dependency
+      (when (:old-group-id opts)
+        (util/with-temp-cwd
+          (pom/spit-old-group-id-pom opts)
+          (mvn "deploy")))
+
       (prepend-changelog-placeholders)
       (git/git! "add" "pom.xml")
       (util/do-modules opts (fn [_] (git/git! "add" "pom.xml")))


### PR DESCRIPTION
This PR addresses #9.

When `:old-group-id` is given to `release`, after deploying the main artifact, creates a temp directory with a `pom.xml` for `:old-group-id` having a single dependency on the main library, and does `mvn deploy` from there. Afterwards, it cleans up the temp directory.