### PR TITLE
Accept deps.edn files without a :paths entry

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
  :deps
- {lambdaisland/regal {:mvn/version "0.0.97"}
-  rewrite-clj/rewrite-clj {:mvn/version "1.0.605-alpha"}
-  olical/depot {:mvn/version "2.2.0"}}}
+ {lambdaisland/regal {:mvn/version "0.0.143"}
+  rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
+  olical/depot {:mvn/version "2.3.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src" "resources"]
  :deps
- {lambdaisland/regal {:mvn/version "0.0.97"}
-  rewrite-clj/rewrite-clj {:mvn/version "1.0.605-alpha"}
-  olical/depot {:mvn/version "2.2.0"}}
+ {lambdaisland/regal {:mvn/version "0.0.143"}
+  rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
+  olical/depot {:mvn/version "2.3.0"}}
 
  :aliases
  {:build-releases
   {:extra-deps {lambdaisland/janus {:git/url "https://github.com/lambdaisland/janus"
-                                    :sha "1547a8b2edc69e19d051828f481d9a9fe7c08f85"}}
+                                    :sha "77a33f8cb209fffed40d60515fcf2092befa9972"}}
    :main-opts ["-m" "lioss.releases"]}}}

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -79,7 +79,8 @@
    :date           (str (java.time.LocalDate/now))
    :latest-version (or (git/last-released-version) "0.0.0")
    :authors        (when (.exists (io/file "AUTHORS"))
-                     (str/split (str/trim (slurp "AUTHORS")) #"\R"))})
+                     (str/split (str/trim (slurp "AUTHORS")) #"\R"))
+   :paths          ["src"]})
 
 (defn main [opts]
   (assert (:group-id opts) ":group-id should be set explicitly to \"lambdaisland\" or \"com.lambdaisland\"")


### PR DESCRIPTION
This should default to ["src"], the way tools.deps does too.;

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
