### PR TITLE
Add kaocha-cucumber doc build command.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,10 +4,13 @@
   rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
   olical/depot {:mvn/version "2.3.0"}
   lambdaisland/tools.namespace {:mvn/version "0.1.247"}
-  lambdaisland/kaocha-cucumber {:mvn/version "0.0-53"}}
+  }
 
  :aliases
  {:build-releases
   {:extra-deps {lambdaisland/janus {:git/url "https://github.com/lambdaisland/janus"
                                     :sha "77a33f8cb209fffed40d60515fcf2092befa9972"}}
-   :main-opts ["-m" "lioss.releases"]}}}
+   :main-opts ["-m" "lioss.releases"]}
+  :cucumber 
+  {:extra-deps {lambdaisland/kaocha-cucumber {:mvn/version "0.0-53"}}
+   :main-opts ["-m" "lioss.cucumber"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,9 @@
  :deps
  {lambdaisland/regal {:mvn/version "0.0.143"}
   rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
-  olical/depot {:mvn/version "2.3.0"}}
+  olical/depot {:mvn/version "2.3.0"}
+  lambdaisland/tools.namespace {:mvn/version "0.1.247"}
+  lambdaisland/kaocha-cucumber {:mvn/version "0.0-53"}}
 
  :aliases
  {:build-releases

--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,7 @@
  {lambdaisland/regal {:mvn/version "0.0.143"}
   rewrite-clj/rewrite-clj {:mvn/version "1.1.45"}
   olical/depot {:mvn/version "2.3.0"}
-  lambdaisland/tools.namespace {:mvn/version "0.1.247"}
-  }
+  lambdaisland/tools.namespace {:mvn/version "0.1.247"}}
 
  :aliases
  {:build-releases

--- a/src/lioss/cucumber.clj
+++ b/src/lioss/cucumber.clj
@@ -5,7 +5,8 @@
             [clojure.string :as str]
             [clojure.java.io :as io]))
 
-(def pregenerated-notice "<!-- This document is generated based on a corresponding .feature file, do not edit directly -->\n\n")
+(def pregenerated-notice
+  "<!-- This document is generated based on a corresponding .feature file, do not edit directly -->\n\n")
 
 (defn list-cucumber-docs
   "Lists any cucumber docs.
@@ -13,20 +14,20 @@
   Does not examine the test configuration, just looks for .feature files."
   [repository-path]
   (->> repository-path
-                 io/file
-                 file-seq
-                 (map str)
-                 (filter #(str/ends-with? % ".feature"))))
+       io/file
+       file-seq
+       (map str)
+       (filter #(str/ends-with? % ".feature"))))
 
-(defn has-cucumber-docs? 
+(defn has-cucumber-docs?
   "Determines whether a repository path contains cucumber feature files with docs to (re)generate."
   [repository-path]
-  (boolean (and (.exists (io/file repository-path)) (take 1 (list-cucumber-docs repository-path)))))
+  (boolean (and (.exists (io/file repository-path))
+                (take 1 (list-cucumber-docs repository-path)))))
 
 (defn generate-docs
   "Generates Cucumber documentation for the repository"
-  ([]
-   (generate-docs "."))
+  ([] (generate-docs "."))
   ([repo-path]
    (doseq [f (list-cucumber-docs repo-path)]
      (with-open [out (-> f
@@ -40,10 +41,8 @@
               gherkin/gherkin->edn
               cucumber-output/print-markdown))))))
 
-
-(defn -main [& args]
+(defn -main
+  [& args]
   (if-let [repository (first args)]
-    (do 
-      (println "Generating docs")
-      (generate-docs repository))
+    (do (println "Generating docs") (generate-docs repository))
     (println "Warning: No repository supplied")))

--- a/src/lioss/cucumber.clj
+++ b/src/lioss/cucumber.clj
@@ -3,8 +3,9 @@
             [lambdaisland.cucumber.output :as cucumber-output]
             [lambdaisland.cucumber.gherkin :as gherkin]
             [clojure.string :as str]
-            [clojure.java.io :as io])
-  )
+            [clojure.java.io :as io]))
+
+(def pregenerated-notice "<!-- This document is generated based on a corresponding .feature file, do not edit directly -->\n\n")
 
 (defn list-cucumber-docs
   "Lists any cucumber docs.
@@ -18,6 +19,7 @@
                  (filter #(str/ends-with? % ".feature"))))
 
 (defn has-cucumber-docs? 
+  "Determines whether a repository path contains cucumber feature files with docs to (re)generate."
   [repository-path]
   (boolean (and (.exists (io/file repository-path)) (take 1 (list-cucumber-docs repository-path)))))
 
@@ -32,12 +34,16 @@
                          (str/replace ".feature" ".md")
                          io/writer)]
        (binding [*out* out]
+         (print pregenerated-notice)
          (->> f
               jvm/parse
               gherkin/gherkin->edn
               cucumber-output/print-markdown))))))
 
 
-(generate-docs "/home/alys/repos/lambdaisland/kaocha/")
-
-
+(defn -main [& args]
+  (if-let [repository (first args)]
+    (do 
+      (println "Generating docs")
+      (generate-docs repository))
+    (println "Warning: No repository supplied")))

--- a/src/lioss/cucumber.clj
+++ b/src/lioss/cucumber.clj
@@ -1,0 +1,43 @@
+(ns lioss.cucumber
+  (:require [lambdaisland.cucumber.jvm :as jvm]
+            [lambdaisland.cucumber.output :as cucumber-output]
+            [lambdaisland.cucumber.gherkin :as gherkin]
+            [clojure.string :as str]
+            [clojure.java.io :as io])
+  )
+
+(defn list-cucumber-docs
+  "Lists any cucumber docs.
+  
+  Does not examine the test configuration, just looks for .feature files."
+  [repository-path]
+  (->> repository-path
+                 io/file
+                 file-seq
+                 (map str)
+                 (filter #(str/ends-with? % ".feature"))))
+
+(defn has-cucumber-docs? 
+  [repository-path]
+  (boolean (and (.exists (io/file repository-path)) (take 1 (list-cucumber-docs repository-path)))))
+
+(defn generate-docs
+  "Generates Cucumber documentation for the repository"
+  ([]
+   (generate-docs "."))
+  ([repo-path]
+   (doseq [f (list-cucumber-docs repo-path)]
+     (with-open [out (-> f
+                         (str/replace "test/features" "doc")
+                         (str/replace ".feature" ".md")
+                         io/writer)]
+       (binding [*out* out]
+         (->> f
+              jvm/parse
+              gherkin/gherkin->edn
+              cucumber-output/print-markdown))))))
+
+
+(generate-docs "/home/alys/repos/lambdaisland/kaocha/")
+
+

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -3,7 +3,6 @@
             [clojure.java.shell :as sh]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
-            [lioss.cucumber :as cucumber]
             [lioss.gh-actions :as gh-actions]
             [lioss.git :as git]
             [lioss.hiccup :as hiccup]
@@ -68,11 +67,7 @@
 
    "bump-version"
    {:description "Bump minor version"
-    :command version/bump-version!}
-
-   "gen-cucumber"
-   {:description "Generate docs from Cucumber"
-    :command  cucumber/generate-docs}])
+    :command version/bump-version!}])
 
 (def defaults
   {:name           (git/project-name)

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -3,6 +3,7 @@
             [clojure.java.shell :as sh]
             [clojure.pprint :as pprint]
             [clojure.string :as str]
+            [lioss.cucumber :as cucumber]
             [lioss.gh-actions :as gh-actions]
             [lioss.git :as git]
             [lioss.hiccup :as hiccup]
@@ -67,7 +68,11 @@
 
    "bump-version"
    {:description "Bump minor version"
-    :command version/bump-version!}])
+    :command version/bump-version!}
+
+   "gen-cucumber"
+   {:description "Generate docs from Cucumber"
+    :command  cucumber/generate-docs}])
 
 (def defaults
   {:name           (git/project-name)


### PR DESCRIPTION
Creates a command to build our cucumber docs.

Babashka cannot load the cucumber libraries, so for this to work, we'll need to create a pod.