### PR TITLE
Add new action - add to project board

### DIFF
--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,6 +1,6 @@
 name: Add a new GitHub Project card linked to a GitHub issue or a new pr to the Triage project column
 
-on: [issues, pull_request]
+on: workflow_call
 
 jobs:
   add-to-project:

--- a/.github/workflows/add-to-project-board.yml
+++ b/.github/workflows/add-to-project-board.yml
@@ -1,0 +1,13 @@
+name: Add a new GitHub Project card linked to a GitHub issue or a new pr to the Triage project column
+
+on: [issues, pull_request]
+
+jobs:
+  add-to-project:
+    name: Add issue or pr to project board marked as Triage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/lambdaisland/projects/2
+          github-token: ${{ secrets.ADD_PROJECT_BOARD }}


### PR DESCRIPTION
setup a github action so that new issues and PRs are automatically added to the project board, with status "Triage".