### PR TITLE
Add ingest-docs command.

### DIFF
--- a/src/lioss/cljdoc.clj
+++ b/src/lioss/cljdoc.clj
@@ -8,8 +8,11 @@
 
 
 (defn ingest
-  "Ingest"
+  "Run cljdoc in Docker to ingest the current version of this project."
   [{:keys [group-id name version] :as opts}]
   (release/do-install opts)
 
-  (subshell/spawn "docker" "run" "--volume" (str (System/getProperty "user.home") "/.m2:/root/.m2") "--volume" "/tmp/cljdoc:/app/data" "--entrypoint" "clojure" "cljdoc/cljdoc" "-Sforce" "-M:cli" "ingest" "--project" (str group-id "/" name) "--version" version))
+  (subshell/spawn "docker" "run" "--volume" (str (System/getProperty "user.home") "/.m2:/root/.m2") 
+                  "--volume" "/tmp/cljdoc:/app/data" "--entrypoint" "clojure" 
+                  "cljdoc/cljdoc" "-Sforce" "-M:cli" "ingest" 
+                  "--project" (str group-id "/" name) "--version" version))

--- a/src/lioss/cljdoc.clj
+++ b/src/lioss/cljdoc.clj
@@ -1,0 +1,16 @@
+(ns lioss.cljdoc
+
+(:require [clojure.java.io :as io]
+          [clojure.string :as str]
+          [lioss.subshell :as subshell]
+          [lioss.release :as release]
+          [lioss.util :as util]))
+
+
+(defn ingest
+  "Ingest"
+  [opts]
+  (release/do-install opts)
+
+  (subshell/spawn "docker" "run" "--volume" (str (System/getProperty "user.home")   "/.m2:/root/.m2") "--volume" "/tmp/cljdoc:/app/data" "--entrypoint" "clojure" "cljdoc/cljdoc" "-Sforce" "-M:cli" "ingest" "--project" "lambdaisland/kaocha-cljs2" "--version" "0.1.67" )
+  )

--- a/src/lioss/cljdoc.clj
+++ b/src/lioss/cljdoc.clj
@@ -9,8 +9,7 @@
 
 (defn ingest
   "Ingest"
-  [opts]
+  [{:keys [group-id name version] :as opts}]
   (release/do-install opts)
 
-  (subshell/spawn "docker" "run" "--volume" (str (System/getProperty "user.home")   "/.m2:/root/.m2") "--volume" "/tmp/cljdoc:/app/data" "--entrypoint" "clojure" "cljdoc/cljdoc" "-Sforce" "-M:cli" "ingest" "--project" "lambdaisland/kaocha-cljs2" "--version" "0.1.67" )
-  )
+  (subshell/spawn "docker" "run" "--volume" (str (System/getProperty "user.home") "/.m2:/root/.m2") "--volume" "/tmp/cljdoc:/app/data" "--entrypoint" "clojure" "cljdoc/cljdoc" "-Sforce" "-M:cli" "ingest" "--project" (str group-id "/" name) "--version" version))

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -4,6 +4,7 @@
             [clojure.pprint :as pprint]
             [clojure.string :as str]
             [lambdaisland.launchpad :as launchpad]
+            [lioss.cljdoc :as cljdoc]
             [lioss.gh-actions :as gh-actions]
             [lioss.git :as git]
             [lioss.hiccup :as hiccup]
@@ -73,7 +74,11 @@
    "launchpad"
    {:description "Launch a REPL with Launchpad"
     :command (fn [_]
-               (launchpad/main {:steps (into [(partial launchpad/ensure-java-version 17)] launchpad/default-steps)}))}])
+               (launchpad/main {:steps (into [(partial launchpad/ensure-java-version 17)] launchpad/default-steps)}))}
+
+   "ingest-docs"
+   {:description "Start a docker container to "
+    :command cljdoc/ingest}])
 
 (def defaults
   {:name           (git/project-name)

--- a/src/lioss/main.clj
+++ b/src/lioss/main.clj
@@ -77,7 +77,7 @@
                (launchpad/main {:steps (into [(partial launchpad/ensure-java-version 17)] launchpad/default-steps)}))}
 
    "ingest-docs"
-   {:description "Start a docker container to "
+   {:description "Start a Cljdoc Docker container to analyze and ingest docs."
     :command cljdoc/ingest}])
 
 (def defaults


### PR DESCRIPTION
Start of a new `bin/proj` subcommand to run the docker command to analyze the latest changes with Cljdoc.